### PR TITLE
Make sure there is a bare Exifdata object always

### DIFF
--- a/lib/Image/Libexif.rakumod
+++ b/lib/Image/Libexif.rakumod
@@ -140,7 +140,7 @@ submethod BUILD(Str :$file?, Buf :$data?)
 {
   with $file {
     if $file.IO.f {
-      $!exif = exif_data_new_from_file $file;
+      $!exif = exif_data_new_from_file($file) // exif_data_new;
     } else {
       fail X::Libexif.new: errno => 1, error => "File $file not found";
     }
@@ -154,7 +154,7 @@ submethod BUILD(Str :$file?, Buf :$data?)
 method open(Str $file!)
 {
   fail X::Libexif.new: errno => 1, error => "File $file not found" if ! $file.IO.e;
-  $!exif = exif_data_new_from_file $file;
+  $!exif = exif_data_new_from_file($file) // exif_data_new;
   self;
 }
 


### PR DESCRIPTION
It appears that some files don't actually contain any exif data. Creating an object with such a file would put a type object into the $!exif attribute, causing later havoc.

This commit ensures that that is at least a bare ExifData object created when loading a file that doesn't contain any exif data.

An example of such a file is:

   nqp/MoarVM/3rdparty/libuv/docs/src/static/architecture.png

in any Rakudo installation.

Fixes issue #1